### PR TITLE
Allow casting bufferedResponseWriter to http.Pusher

### DIFF
--- a/session.go
+++ b/session.go
@@ -253,6 +253,13 @@ func (bw *bufferedResponseWriter) WriteHeader(code int) {
 	bw.code = code
 }
 
+func (bw *bufferedResponseWriter) Push(target string, opts *http.PushOptions) error {
+	if pusher, ok := bw.ResponseWriter.(http.Pusher); ok {
+		return pusher.Push(target, opts)
+	}
+	return http.ErrNotSupported
+}
+
 func defaultErrorHandler(w http.ResponseWriter, r *http.Request, err error) {
 	log.Output(2, err.Error())
 	http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)


### PR DESCRIPTION
Hello,

I've been using the library to manage sessions in a tutorial app, and I noticed that I wasn't able to perform HTTP2 server pushes. Looking into the issue, I noticed that since this library wraps the `http.ResponseWriter` in a custom type, removing the possibility of casting the `ResponseWriter` received by the final `http.Handler` into a `http.Pusher`. This PR implements the `http.Pusher` interface to maintain the HTTP2 server push capabilities of the original `ResponseWriter`.

If you'd like to me to add tests or additional documentation/examples, please let me know.