### PR TITLE
Allow to set alternative cookie name

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -70,8 +70,8 @@ func TestDestroy(t *testing.T) {
 
 	_, cookie := testRequest(t, s.Enable(h), "")
 
-	if !strings.HasPrefix(cookie, fmt.Sprintf("%s=;", cookieName)) {
-		t.Errorf("got %q: expected prefix %q", cookie, fmt.Sprintf("%s=;", cookieName))
+	if !strings.HasPrefix(cookie, fmt.Sprintf("%s=;", s.CookieName)) {
+		t.Errorf("got %q: expected prefix %q", cookie, fmt.Sprintf("%s=;", s.CookieName))
 	}
 	if !strings.Contains(cookie, "Expires=Thu, 01 Jan 1970 00:00:01 GMT") {
 		t.Errorf("got %q: expected to contain %q", cookie, "Expires=Thu, 01 Jan 1970 00:00:01 GMT")
@@ -121,7 +121,7 @@ func TestInvalidCookies(t *testing.T) {
 	s := New([]byte("u46IpCV9y5Vlur8YvODJEhgOY8m9JVE4"))
 
 	cookie := &http.Cookie{
-		Name:  cookieName,
+		Name:  s.CookieName,
 		Value: "",
 	}
 
@@ -135,7 +135,7 @@ func TestInvalidCookies(t *testing.T) {
 	}
 
 	cookie = &http.Cookie{
-		Name:  cookieName,
+		Name:  s.CookieName,
 		Value: "`",
 	}
 


### PR DESCRIPTION
I really like this simple and yet powerful package, which I use in my project.

What I found impossible to do is:
- to overcome the limit of collisions with other packages which already use their own `session` cookie;
- also it would be nice to have a way to extend the 4096 bytes limit, by simply creating an additional cookie with another name.
- from architectural perspective, it's also can be useful to logically separate cookies of different types: for session, for flash messages, for bookmarks etc.

In that relation I'm offering to add the following change.